### PR TITLE
Fix problem with activestorage and improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.11](https://github.com/jorgemanrubia/turbolinks_render/pull/11)
+
+- Fix problem with active storage
+- Performance improvements
+
 ## 0.9.10
 
 - Use turbolinks code to replace page contents

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbolinks_render (0.9.10)
+    turbolinks_render (0.9.11)
       rails (>= 5.2.0)
       turbolinks-source (~> 5.1)
 

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -12,19 +12,22 @@ module TurbolinksRender
 
       return [@status, @headers, @response] unless render_with_turbolinks?
 
-      body = ''
-      @response.each{|part| body << part}
-      body = render_body_with_turbolinks(body)
-      [@status, @headers, [body]]
+      [@status, @headers, [render_body_with_turbolinks]]
     end
 
     private
 
-    def render_body_with_turbolinks(body)
+    def render_body_with_turbolinks
       @headers["Content-Type"] = 'text/javascript'
-      build_turbolinks_response_to_render(body).tap do |turbolinks_body|
+      build_turbolinks_response_to_render(response_body).tap do |turbolinks_body|
         @headers["Content-Length"] = turbolinks_body.bytesize
       end
+    end
+
+    def response_body
+      body = ''
+      @response.each{|part| body << part}
+      body
     end
 
     def render_with_turbolinks?

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -14,13 +14,13 @@ module TurbolinksRender
 
       body = ''
       @response.each{|part| body << part}
-      body = wrap_with_turboilnks_js_response(body)
+      body = wrap_with_turbolinks_js_response(body)
       [@status, @headers, [body]]
     end
 
     private
 
-    def wrap_with_turboilnks_js_response(body)
+    def wrap_with_turbolinks_js_response(body)
       @headers["Content-Type"] = 'text/javascript'
       build_turbolinks_response_to_render(body).tap do |turbolinks_body|
         @headers["Content-Length"] = turbolinks_body.bytesize

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -14,13 +14,13 @@ module TurbolinksRender
 
       body = ''
       @response.each{|part| body << part}
-      body = render_body_with_turbolinks(body)
+      body = wrap_with_turboilnks_js_response(body)
       [@status, @headers, [body]]
     end
 
     private
 
-    def render_body_with_turbolinks(body)
+    def wrap_with_turboilnks_js_response(body)
       @headers["Content-Type"] = 'text/javascript'
       build_turbolinks_response_to_render(body).tap do |turbolinks_body|
         @headers["Content-Length"] = turbolinks_body.bytesize

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -14,13 +14,13 @@ module TurbolinksRender
 
       body = ''
       @response.each{|part| body << part}
-      body = wrap_with_turbolinks_js_response(body)
+      body = build_turbolinks_js_response(body)
       [@status, @headers, [body]]
     end
 
     private
 
-    def wrap_with_turbolinks_js_response(body)
+    def build_turbolinks_js_response(body)
       @headers["Content-Type"] = 'text/javascript'
       build_turbolinks_response_to_render(body).tap do |turbolinks_body|
         @headers["Content-Length"] = turbolinks_body.bytesize

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -14,13 +14,13 @@ module TurbolinksRender
 
       body = ''
       @response.each{|part| body << part}
-      body = build_turbolinks_js_response(body)
+      body = render_body_with_turbolinks(body)
       [@status, @headers, [body]]
     end
 
     private
 
-    def build_turbolinks_js_response(body)
+    def render_body_with_turbolinks(body)
       @headers["Content-Type"] = 'text/javascript'
       build_turbolinks_response_to_render(body).tap do |turbolinks_body|
         @headers["Content-Length"] = turbolinks_body.bytesize

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -10,10 +10,10 @@ module TurbolinksRender
 
       @status, @headers, @response = @app.call(env)
 
-      return [@status, @headers, @response] if file? || (!@response.respond_to?(:body) && !@response.respond_to?(:[]))
+      return [@status, @headers, @response] if !render_with_turbolinks? || file? || !(@response.respond_to?(:body) || @response.respond_to?(:[]))
 
       body = @response.respond_to?(:body) ? @response.body : @response[0]
-      body = render_body_with_turbolinks(body) if render_with_turbolinks?
+      body = render_body_with_turbolinks(body)
       [@status, @headers, [body]]
     end
 

--- a/lib/turbolinks_render/version.rb
+++ b/lib/turbolinks_render/version.rb
@@ -1,3 +1,3 @@
 module TurbolinksRender
-  VERSION = '0.9.10'
+  VERSION = '0.9.11'
 end


### PR DESCRIPTION
- This reworks the way the middleware was processing response bodies. It will now rely on `#each`, according to Rack spec, instead of trying to discover supported methods with `respond_to?`

- It also saves a bunch of computing for requests that won't be processed at all.

- It refactors the middleware code by extracting classes for dealing with requests and responses

Fix #10 
Fix #9 