### PR TITLE
Don't handle empty responses with turbolinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.9.12](https://github.com/jorgemanrubia/turbolinks_render/issues/12)
+
+- Don't handle empty responses with Turbolinks
+
 ## [0.9.11](https://github.com/jorgemanrubia/turbolinks_render/pull/11)
 
 - Fix problem with active storage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbolinks_render (0.9.11)
+    turbolinks_render (0.9.12)
       rails (>= 5.2.0)
       turbolinks-source (~> 5.1)
 

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -12,7 +12,7 @@ module TurbolinksRender
 
     Response = Struct.new(:status, :headers, :response) do
       def candidate_for_turbolinks?
-        html_response?
+        html_response? && !empty?
       end
 
       def turbolinks_body
@@ -21,14 +21,21 @@ module TurbolinksRender
 
       private
 
+      def empty?
+        body.blank?
+      end
+
       def html_response?
         headers['Content-Type'] =~ /text\/html/
       end
 
       def body
-        body = ''
-        response.each {|part| body << part}
-        body
+        @body ||= begin
+          body = ''
+          # Response does not have to be an Enumerable. It just has to respond to #each according to Rack spec
+          response.each {|part| body << part}
+          body
+        end
       end
 
       def js_code_to_render_html(html)

--- a/lib/turbolinks_render/version.rb
+++ b/lib/turbolinks_render/version.rb
@@ -1,3 +1,3 @@
 module TurbolinksRender
-  VERSION = '0.9.11'
+  VERSION = '0.9.12'
 end

--- a/test/dummy/app/controllers/tasks_controller.rb
+++ b/test/dummy/app/controllers/tasks_controller.rb
@@ -28,6 +28,8 @@ class TasksController < ApplicationController
       raise 'OMG this is a 500 error'
     when 'force script response'
       render 'response_with_script_tags'
+    when 'force empty response'
+      head :ok, content_type: 'text/html'
     else
       @task = Task.new(task_params)
 

--- a/test/system/rendering_test.rb
+++ b/test/system/rendering_test.rb
@@ -29,6 +29,13 @@ class TurbolinksRenderingTest < ApplicationSystemTestCase
     end
   end
 
+  test 'Empty responses will not clear the page' do
+    with_default_option_for_rendering_with_turbolinks(true) do
+      create_task_with_title 'force empty response'
+      assert_content 'New Task'
+    end
+  end
+
   def create_task_with_title(title)
     visit new_task_path
     fill_in 'Title', with: title


### PR DESCRIPTION
Fix #12
