### PR TITLE
Added "turbolinks:before-cache" event before render html.

### DIFF
--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -56,6 +56,7 @@ module TurbolinksRender
             renderer.render(nullCallback);
           }
           Turbolinks.clearCache();
+          Turbolinks.dispatch('turbolinks:before-cache');
           renderWithTurbolinks("#{escaped_html}");
           Turbolinks.dispatch('turbolinks:load');
           window.scroll(0, 0);


### PR DESCRIPTION
Thanks for creating great gem!

I usually reset DOM state using "turbolinks:before-cache" event, so I realize we maybe need dispatch this event before rendering html.
see: https://github.com/turbolinks/turbolinks#preparing-the-page-to-be-cached

I added few code and works well.
Please check. 😄