### PR TITLE
Configuration to ignore paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ In this case, to use turbolinks you should write:
 render turbolinks: true
 ```
 
+You can also ignore specific paths in your application. This can be useful if you're using an engine and don't have access to its code to change the `render` calls. For instance, to ignore anything that starts with `/admin`:
+
+```ruby
+Rails.application.config.turbolinks_render.ignored_paths = [
+  '/admin'
+]
+```
+
 ## Implementation notes
 
 - It configures a rack middleware that intercept requests and modify responses when the expected conditions are met.

--- a/lib/turbolinks_render.rb
+++ b/lib/turbolinks_render.rb
@@ -17,6 +17,7 @@ module TurbolinksRender
   class Engine < ::Rails::Railtie
     config.turbolinks_render = ActiveSupport::OrderedOptions.new
     config.turbolinks_render.render_with_turbolinks_by_default = true
+    config.turbolinks_render.ignored_paths = []
 
     initializer :turbolinks_render do |app|
       app.config.app_middleware.insert_before ActionDispatch::ShowExceptions, TurbolinksRender::Middleware

--- a/lib/turbolinks_render/middleware.rb
+++ b/lib/turbolinks_render/middleware.rb
@@ -8,6 +8,10 @@ module TurbolinksRender
       def turbolinks_render_option
         @turbolinks_render_option ||= request.get_header('X-Turbolinks-Render-Option')
       end
+
+      def fullpath
+        request.fullpath
+      end
     end
 
     Response = Struct.new(:status, :headers, :response) do
@@ -89,11 +93,16 @@ module TurbolinksRender
 
     def render_with_turbolinks?(request, response)
       request.candidate_for_turbolinks? && response.candidate_for_turbolinks? &&
+        ignored_paths.none? { |path| request.fullpath.starts_with?(path) } &&
         (request.turbolinks_render_option || (render_with_turbolinks_by_default? && request.turbolinks_render_option != false))
     end
 
     def render_with_turbolinks_by_default?
       Rails.application.config.turbolinks_render.render_with_turbolinks_by_default
+    end
+
+    def ignored_paths
+      Rails.application.config.turbolinks_render.ignored_paths
     end
   end
 end

--- a/test/controllers/rendering_controller_test.rb
+++ b/test/controllers/rendering_controller_test.rb
@@ -35,6 +35,17 @@ class RenderingControllerTest < ActionDispatch::IntegrationTest
       send http_verb, update_with_turbolinks_forcing_it_tasks_url, xhr: true
       assert_js_function_in_response
     end
+
+    test "Turbolinks can be ignored for specific paths and their subpaths for #{http_verb} requests" do
+      Rails.application.config.turbolinks_render.render_with_turbolinks_by_default = true
+      Rails.application.config.turbolinks_render.ignored_paths = ['/tasks/update_ignored']
+      send http_verb, update_ignored_tasks_url, xhr: true
+      assert_no_match(/function/, response.body)
+      assert_equal 'text/html', @response.content_type
+      send http_verb, update_ignored_subpath_tasks_url, xhr: true
+      assert_no_match(/function/, response.body)
+      assert_equal 'text/html', @response.content_type
+    end
   end
 
   def assert_js_function_in_response

--- a/test/dummy/app/controllers/tasks_controller.rb
+++ b/test/dummy/app/controllers/tasks_controller.rb
@@ -72,6 +72,12 @@ class TasksController < ApplicationController
     raise 'OMG this is a 500 error'
   end
 
+  def update_ignored; end
+
+  def update_ignored_subpath
+    render action: 'update_ignored'
+  end
+
   private
 
   # Use callbacks to share common setup or constraints between actions.

--- a/test/dummy/app/views/tasks/update_ignored.html.erb
+++ b/test/dummy/app/views/tasks/update_ignored.html.erb
@@ -1,0 +1,1 @@
+<p>Ignored</p>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
         send verb, :update_with_turbolinks_forcing_it
         send verb, :update_without_turbolinks
         send verb, :update_with_json_response
+        send verb, :update_ignored
+        send verb, 'update_ignored/subpath', action: 'update_ignored_subpath'
       end
     end
   end


### PR DESCRIPTION
I've been having some issues with a gem called [blazer](https://github.com/ankane/blazer). It's a rails engine that uses ajax requests, and inserts the results in the layout. This issue describes the problem: https://github.com/ankane/blazer/issues/278.

There's no way that I can update their responses to `render turbolinks: false`, short of forking their code, since it's an engine. I could set `render_with_turbolinks_by_default` to false, but then I need to find all the relevant responses in my app.

This PR implements a workaround for this kind of situation. It adds a setting to ignore certain paths of the app. If you don't think this is the right way to go, feel free to close the PR. I'm also open to making any changes in terms of code structure, config name, etc. Let me know.