### PR TITLE
Be specific about dependencies and do not depend on the whole `rails` gem

### DIFF
--- a/turbolinks_render.gemspec
+++ b/turbolinks_render.gemspec
@@ -18,7 +18,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
-  s.add_dependency 'rails', ">= #{rails_version}"
+  s.add_dependency 'railties', ">= #{rails_version}"
+  s.add_dependency 'activesupport', ">= #{rails_version}"
+  s.add_dependency 'actionpack', ">= #{rails_version}"
+  
   s.add_dependency 'turbolinks-source', '~> 5.1'
 
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
This PR drops dependency for `rails` and instead specifies dependencies on the actual parts of Rails that the project is dependent on following best practices.

The advantage here is that this gem can be used in projects that does not include the whole `rails` gem, but rather use parts of Rails.